### PR TITLE
Fix Hyper launch for Hyper 3

### DIFF
--- a/WslManager/MainForm.cs
+++ b/WslManager/MainForm.cs
@@ -96,7 +96,7 @@ namespace WslManager
 
         private void LaunchHyper(IEnumerable<ListViewItem> distroItems)
         {
-            string hyperConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".hyper.js");
+            string hyperConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Hyper", ".hyper.js");
             string tempHyperConfigFile = hyperConfigFile + ".tmp";
 
             if (File.Exists(hyperConfigFile))


### PR DESCRIPTION
The [3.0 release](https://github.com/zeit/hyper/releases/tag/3.0.0) for Hyper changed the config location from `<User>\.hyper.js` to `AppData\Roaming\Hyper\.hyper.js` which broke the functionality to open a WSL distro in Hyper. This commit fixes the location.